### PR TITLE
feat: Matrix Rain Screensaver Integration (#41)

### DIFF
--- a/neosetup/operators/matrix/vars.yml
+++ b/neosetup/operators/matrix/vars.yml
@@ -4,7 +4,7 @@
 
 # Operator metadata
 operator_name: "matrix"
-operator_version: "1.2.0"
+operator_version: "1.3.0"
 operator_description: "Matrix-themed cyberpunk aesthetic with green colors"
 extends: "base"
 
@@ -52,6 +52,18 @@ tmux_config:
     foreground: "#00ff00"
     active_bg: "#00ff00"
     active_fg: "#000000"
+
+  # Matrix rain keybindings
+  custom_bindings:
+    - key: "m"
+      command: "run-shell 'cmatrix -s'"
+    - key: "M"
+      command: "run-shell 'cmatrix -b -C green'"
+
+  # Matrix lock screen - use cmatrix as lock command
+  custom_configs:
+    - "set -g lock-command 'cmatrix -s -C green'"
+    - "set -g lock-after-time 600"  # Lock after 10 minutes idle
 
   # Additional Matrix plugins
   plugins:
@@ -150,6 +162,58 @@ shell_functions:
       echo "🟢 System: ONLINE"
       echo "🟢 Neural link: ESTABLISHED"
       echo "🟢 Reality: QUESTIONED"
+
+  - name: "matrix_rain"
+    description: "Digital rain effect with color options"
+    body: |
+      local color="${1:-green}"
+      local mode="${2:-normal}"
+      if ! command -v cmatrix &> /dev/null; then
+        echo "❌ cmatrix not installed. Run: sudo apt install cmatrix"
+        return 1
+      fi
+      case "$color" in
+        green)  color_flag="green" ;;
+        red)    color_flag="red" ;;
+        blue)   color_flag="blue" ;;
+        white)  color_flag="white" ;;
+        yellow) color_flag="yellow" ;;
+        cyan)   color_flag="cyan" ;;
+        magenta) color_flag="magenta" ;;
+        *)      color_flag="green" ;;
+      esac
+      case "$mode" in
+        bold)   cmatrix -b -C "$color_flag" ;;
+        async)  cmatrix -a -C "$color_flag" ;;
+        *)      cmatrix -C "$color_flag" ;;
+      esac
+
+  - name: "matrix_screensaver"
+    description: "Matrix screensaver with idle timeout"
+    body: |
+      local timeout="${1:-300}"
+      local color="${2:-green}"
+      echo "🌧️ Matrix screensaver activated (${timeout}s idle timeout)"
+      echo "Press any key to cancel..."
+      read -t "$timeout" -n 1 && return 0
+      matrix_rain "$color"
+
+  - name: "matrix_colors"
+    description: "Show available Matrix rain colors"
+    body: |
+      echo "🌧️ Matrix Rain Colors:"
+      echo "  green   - Classic Matrix (default)"
+      echo "  red     - Red pill mode"
+      echo "  blue    - Blue pill mode"
+      echo "  white   - Ghost in the shell"
+      echo "  yellow  - Caution mode"
+      echo "  cyan    - Tron mode"
+      echo "  magenta - Synthwave"
+      echo ""
+      echo "Usage: matrix_rain [color] [mode]"
+      echo "Modes: normal, bold, async"
+      echo ""
+      echo "Example: matrix_rain red bold"
 
 # Matrix startup configuration
 matrix_startup:


### PR DESCRIPTION
## Summary

Adds Matrix digital rain screensaver/idle animation to the matrix operator.

## Features Added

### Shell Functions
| Function | Description |
|----------|-------------|
| `matrix_rain [color] [mode]` | Digital rain with customizable colors and modes |
| `matrix_screensaver [timeout] [color]` | Idle-triggered screensaver |
| `matrix_colors` | Display available color options |

### Tmux Integration
| Keybinding | Action |
|------------|--------|
| `prefix + m` | Quick Matrix rain |
| `prefix + M` | Bold Matrix rain |
| Auto-lock (10 min) | cmatrix as lock screen |

### Color Options
- **green** - Classic Matrix (default)
- **red** - Red pill mode
- **blue** - Blue pill mode
- **white** - Ghost in the shell
- **yellow** - Caution mode
- **cyan** - Tron mode
- **magenta** - Synthwave

### Modes
- **normal** - Standard rain
- **bold** - Bold characters
- **async** - Asynchronous updates

## Changes
- Updated `neosetup/operators/matrix/vars.yml`
- Bumped matrix operator version to 1.3.0
- Added 3 new shell functions
- Added 2 tmux keybindings
- Added tmux lock screen with cmatrix

## Test Results
✅ All 27 container tests passing (9 distros × 3 operators)

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)