### PR TITLE
fix: remove branch filter from workflow_run trigger

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -5,9 +5,7 @@ on:
     workflows: ["🚀 NeoSetup CI/CD Pipeline"]
     types:
       - completed
-    branches:
-      - main
-      - develop
+    # No branch filter - run container tests for any successful CI/CD completion
   schedule:
     # Run nightly
     - cron: '0 3 * * *'
@@ -33,13 +31,10 @@ jobs:
   build-test-containers:
     name: 🔨 Build Test Containers
     runs-on: ubuntu-latest
+    # Run on successful CI/CD (any branch), manual dispatch, or schedule
     if: |
       (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       (github.event.workflow_run.head_branch == 'main' ||
-        github.event.workflow_run.head_branch == 'develop' ||
-        startsWith(github.event.workflow_run.head_branch, 'feature/') ||
-        startsWith(github.event.workflow_run.head_branch, 'Feature/'))) ||
+       github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule'
     strategy:


### PR DESCRIPTION
  ## Summary

  Remove hardcoded branch patterns that caused container tests to skip for issue branches like `59-auto-generate-toolsmd-documentation`.

  ## Changes

  - Removed `branches` filter from `workflow_run` trigger
  - Simplified job `if` condition to check only for successful CI/CD completion

  ## Before

  Container tests skipped for branches not matching `main`, `develop`, `feature/*`, or `Feature/*`.

  ## After

  Container tests run for ANY successful CI/CD completion, regardless of branch name.

  Closes #56

  🤖 Generated with [Claude Code](https://claude.com/claude-code)