### PR TITLE
docs: add container test matrix badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,31 @@
 ![Terminal](https://img.shields.io/badge/Terminal-Hacker-000000?style=for-the-badge&logo=gnu-bash&logoColor=00ff00)
 
 [![CI/CD Pipeline](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/ci.yml/badge.svg)](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/ci.yml)
-[![Docker Multi-OS Tests](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml/badge.svg)](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml)
+[![Container Tests](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml/badge.svg)](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml)
 
 **Matrix-themed development environment automation that transforms your terminal into a cyberpunk powerhouse.**
+
+<details>
+<summary>🐳 <b>Container Test Matrix</b> (27 test combinations)</summary>
+<br>
+
+**Operators Tested**
+
+| Operator | Description | Status |
+|----------|-------------|--------|
+| ![base](https://img.shields.io/badge/base-essential_tools-blue) | Minimal essentials | [![base](https://img.shields.io/github/actions/workflow/status/j1v37u2k3y/NeoSetup/container-tests.yml?label=tests)](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml) |
+| ![matrix](https://img.shields.io/badge/matrix-cyberpunk-00ff00) | Matrix-themed | [![matrix](https://img.shields.io/github/actions/workflow/status/j1v37u2k3y/NeoSetup/container-tests.yml?label=tests)](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml) |
+| ![jiveturkey](https://img.shields.io/badge/jiveturkey-power_user-red) | Full power-user | [![jiveturkey](https://img.shields.io/github/actions/workflow/status/j1v37u2k3y/NeoSetup/container-tests.yml?label=tests)](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml) |
+
+**Distributions Tested**
+
+| Family | Distribution | Status |
+|--------|--------------|--------|
+| ![Debian](https://img.shields.io/badge/Debian-based-A81D33?logo=debian) | Ubuntu 22.04, Ubuntu 24.04, Debian 12 | [![debian](https://img.shields.io/github/actions/workflow/status/j1v37u2k3y/NeoSetup/container-tests.yml?label=passing)](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml) |
+| ![Security](https://img.shields.io/badge/Security-distros-557C94?logo=kalilinux) | Kali Rolling, Parrot Security | [![security](https://img.shields.io/github/actions/workflow/status/j1v37u2k3y/NeoSetup/container-tests.yml?label=passing)](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml) |
+| ![RHEL](https://img.shields.io/badge/RHEL-based-EE0000?logo=redhat) | CentOS Stream 9, Rocky 9, AlmaLinux 9, Fedora 40 | [![rhel](https://img.shields.io/github/actions/workflow/status/j1v37u2k3y/NeoSetup/container-tests.yml?label=passing)](https://github.com/j1v37u2k3y/NeoSetup/actions/workflows/container-tests.yml) |
+
+</details>
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
# 🚀 NeoSetup Pull Request

## 📋 Description

Add a collapsible container test matrix section to README with dynamic shields.io badges showing workflow status for all operators and distributions.

## 🎯 Type of Change

- [x] 📚 Documentation update

## 🎯 Operator/Component Affected

- [x] 🎯 Base Operator
- [x] 🟢 Matrix Operator
- [x] 🦃 JiveTurkey Operator
- [x] 📚 Documentation

## ✅ Testing Checklist

- [x] 🐳 Pre-commit passes
- [x] 🧪 All existing tests pass
- [x] 📚 Documentation updated

## 🔗 Related Issues

- Closes #65

## 📚 Additional Notes

- Operators table with dynamic status badges
- Distribution families (Debian, Security, RHEL) with logos
- Collapsible section keeps README clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)