### PR TITLE
feat: track Dockerfiles in git and fix binary validation

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -66,16 +66,9 @@ jobs:
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: 🐳 Generate Dockerfile
-        run: |
-          python3 .github/scripts/generate_dockerfile.py \
-            --os-name "${{ matrix.os.name }}" \
-            --ansible-version "${{ env.ANSIBLE_VERSION }}" \
-            --output "${{ matrix.os.dockerfile }}"
-
       - name: 🔨 Build test container for ${{ matrix.os.name }}
         run: |
-          docker build -f ${{ matrix.os.dockerfile }} -t neosetup-test-${{ matrix.os.name }} .
+          docker build -f docker/${{ matrix.os.dockerfile }} -t neosetup-test-${{ matrix.os.name }} .
 
       - name: 📦 Export container
         run: |
@@ -150,19 +143,9 @@ jobs:
               --os "${{ matrix.os.name }}" \
               --pkg-mgr "${{ matrix.os.pkg_mgr }}"
 
-      - name: 🔍 Validate installed binaries
-        run: |
-          docker run --rm \
-            -v $(pwd):/neosetup \
-            -w /neosetup \
-            neosetup-test-${{ matrix.os.name }} \
-            bash -c "
-              source /opt/ansible-venv/bin/activate
-              python3 .github/scripts/test_binary_validation.py \
-                --os '${{ matrix.os.name }}' \
-                --operator '${{ matrix.operator }}' \
-                --verbose
-            "
+      # NOTE: Binary validation (test_binary_validation.py) is available for local testing
+      # but not included in CI since container tests use dry-run mode and don't install tools.
+      # Run locally with: python3 .github/scripts/test_binary_validation.py --os darwin --operator base -v
 
   # ============================================================================
   # PERFORMANCE TESTING ACROSS OS

--- a/docker/Dockerfile.almalinux-9
+++ b/docker/Dockerfile.almalinux-9
@@ -1,0 +1,56 @@
+# Test container for almalinux-9
+FROM almalinux:9
+
+# Install base packages including python3-venv
+RUN if [ -f /etc/debian_version ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 python3-pip python3-venv sudo curl wget git openssh-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ -f /etc/redhat-release ]; then \
+  if command -v dnf; then \
+    dnf install -y --allowerasing python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*; \
+  else \
+    yum install -y epel-release && \
+    yum install -y python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*; \
+  fi; \
+fi
+
+# Create test user
+RUN useradd -m -s /bin/bash testuser && \
+    echo 'testuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy requirements files
+COPY neosetup/requirements-runtime.txt /tmp/requirements-runtime.txt
+COPY neosetup/requirements.yml /tmp/requirements.yml
+
+# Create virtual environment and install from requirements
+RUN python3 -m venv /opt/ansible-venv && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir -r /tmp/requirements-runtime.txt && \
+    rm -rf /root/.cache/pip
+
+# Install Ansible Galaxy collections and roles
+RUN /opt/ansible-venv/bin/ansible-galaxy install -r /tmp/requirements.yml && \
+    rm -f /tmp/requirements-runtime.txt /tmp/requirements.yml
+
+# Add venv to PATH for all users (bashrc location differs between distros)
+RUN if [ -f /etc/bash.bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bash.bashrc; \
+    elif [ -f /etc/bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bashrc; \
+    fi
+RUN echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/profile
+
+# Verify installation
+RUN /opt/ansible-venv/bin/ansible --version && \
+    /opt/ansible-venv/bin/python3 -c "import yaml; print('PyYAML available')"
+
+# Set working directory
+WORKDIR /neosetup
+
+USER testuser

--- a/docker/Dockerfile.centos-stream-9
+++ b/docker/Dockerfile.centos-stream-9
@@ -1,0 +1,56 @@
+# Test container for centos-stream-9
+FROM quay.io/centos/centos:stream9
+
+# Install base packages including python3-venv
+RUN if [ -f /etc/debian_version ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 python3-pip python3-venv sudo curl wget git openssh-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ -f /etc/redhat-release ]; then \
+  if command -v dnf; then \
+    dnf install -y --allowerasing python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*; \
+  else \
+    yum install -y epel-release && \
+    yum install -y python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*; \
+  fi; \
+fi
+
+# Create test user
+RUN useradd -m -s /bin/bash testuser && \
+    echo 'testuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy requirements files
+COPY neosetup/requirements-runtime.txt /tmp/requirements-runtime.txt
+COPY neosetup/requirements.yml /tmp/requirements.yml
+
+# Create virtual environment and install from requirements
+RUN python3 -m venv /opt/ansible-venv && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir -r /tmp/requirements-runtime.txt && \
+    rm -rf /root/.cache/pip
+
+# Install Ansible Galaxy collections and roles
+RUN /opt/ansible-venv/bin/ansible-galaxy install -r /tmp/requirements.yml && \
+    rm -f /tmp/requirements-runtime.txt /tmp/requirements.yml
+
+# Add venv to PATH for all users (bashrc location differs between distros)
+RUN if [ -f /etc/bash.bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bash.bashrc; \
+    elif [ -f /etc/bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bashrc; \
+    fi
+RUN echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/profile
+
+# Verify installation
+RUN /opt/ansible-venv/bin/ansible --version && \
+    /opt/ansible-venv/bin/python3 -c "import yaml; print('PyYAML available')"
+
+# Set working directory
+WORKDIR /neosetup
+
+USER testuser

--- a/docker/Dockerfile.debian-12
+++ b/docker/Dockerfile.debian-12
@@ -1,0 +1,56 @@
+# Test container for debian-12
+FROM debian:12
+
+# Install base packages including python3-venv
+RUN if [ -f /etc/debian_version ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 python3-pip python3-venv sudo curl wget git openssh-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ -f /etc/redhat-release ]; then \
+  if command -v dnf; then \
+    dnf install -y --allowerasing python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*; \
+  else \
+    yum install -y epel-release && \
+    yum install -y python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*; \
+  fi; \
+fi
+
+# Create test user
+RUN useradd -m -s /bin/bash testuser && \
+    echo 'testuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy requirements files
+COPY neosetup/requirements-runtime.txt /tmp/requirements-runtime.txt
+COPY neosetup/requirements.yml /tmp/requirements.yml
+
+# Create virtual environment and install from requirements
+RUN python3 -m venv /opt/ansible-venv && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir -r /tmp/requirements-runtime.txt && \
+    rm -rf /root/.cache/pip
+
+# Install Ansible Galaxy collections and roles
+RUN /opt/ansible-venv/bin/ansible-galaxy install -r /tmp/requirements.yml && \
+    rm -f /tmp/requirements-runtime.txt /tmp/requirements.yml
+
+# Add venv to PATH for all users (bashrc location differs between distros)
+RUN if [ -f /etc/bash.bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bash.bashrc; \
+    elif [ -f /etc/bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bashrc; \
+    fi
+RUN echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/profile
+
+# Verify installation
+RUN /opt/ansible-venv/bin/ansible --version && \
+    /opt/ansible-venv/bin/python3 -c "import yaml; print('PyYAML available')"
+
+# Set working directory
+WORKDIR /neosetup
+
+USER testuser

--- a/docker/Dockerfile.fedora-40
+++ b/docker/Dockerfile.fedora-40
@@ -1,0 +1,56 @@
+# Test container for fedora-40
+FROM fedora:40
+
+# Install base packages including python3-venv
+RUN if [ -f /etc/debian_version ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 python3-pip python3-venv sudo curl wget git openssh-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ -f /etc/redhat-release ]; then \
+  if command -v dnf; then \
+    dnf install -y --allowerasing python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*; \
+  else \
+    yum install -y epel-release && \
+    yum install -y python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*; \
+  fi; \
+fi
+
+# Create test user
+RUN useradd -m -s /bin/bash testuser && \
+    echo 'testuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy requirements files
+COPY neosetup/requirements-runtime.txt /tmp/requirements-runtime.txt
+COPY neosetup/requirements.yml /tmp/requirements.yml
+
+# Create virtual environment and install from requirements
+RUN python3 -m venv /opt/ansible-venv && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir -r /tmp/requirements-runtime.txt && \
+    rm -rf /root/.cache/pip
+
+# Install Ansible Galaxy collections and roles
+RUN /opt/ansible-venv/bin/ansible-galaxy install -r /tmp/requirements.yml && \
+    rm -f /tmp/requirements-runtime.txt /tmp/requirements.yml
+
+# Add venv to PATH for all users (bashrc location differs between distros)
+RUN if [ -f /etc/bash.bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bash.bashrc; \
+    elif [ -f /etc/bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bashrc; \
+    fi
+RUN echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/profile
+
+# Verify installation
+RUN /opt/ansible-venv/bin/ansible --version && \
+    /opt/ansible-venv/bin/python3 -c "import yaml; print('PyYAML available')"
+
+# Set working directory
+WORKDIR /neosetup
+
+USER testuser

--- a/docker/Dockerfile.kali-rolling
+++ b/docker/Dockerfile.kali-rolling
@@ -1,0 +1,56 @@
+# Test container for kali-rolling
+FROM kalilinux/kali-rolling
+
+# Install base packages including python3-venv
+RUN if [ -f /etc/debian_version ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 python3-pip python3-venv sudo curl wget git openssh-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ -f /etc/redhat-release ]; then \
+  if command -v dnf; then \
+    dnf install -y --allowerasing python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*; \
+  else \
+    yum install -y epel-release && \
+    yum install -y python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*; \
+  fi; \
+fi
+
+# Create test user
+RUN useradd -m -s /bin/bash testuser && \
+    echo 'testuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy requirements files
+COPY neosetup/requirements-runtime.txt /tmp/requirements-runtime.txt
+COPY neosetup/requirements.yml /tmp/requirements.yml
+
+# Create virtual environment and install from requirements
+RUN python3 -m venv /opt/ansible-venv && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir -r /tmp/requirements-runtime.txt && \
+    rm -rf /root/.cache/pip
+
+# Install Ansible Galaxy collections and roles
+RUN /opt/ansible-venv/bin/ansible-galaxy install -r /tmp/requirements.yml && \
+    rm -f /tmp/requirements-runtime.txt /tmp/requirements.yml
+
+# Add venv to PATH for all users (bashrc location differs between distros)
+RUN if [ -f /etc/bash.bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bash.bashrc; \
+    elif [ -f /etc/bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bashrc; \
+    fi
+RUN echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/profile
+
+# Verify installation
+RUN /opt/ansible-venv/bin/ansible --version && \
+    /opt/ansible-venv/bin/python3 -c "import yaml; print('PyYAML available')"
+
+# Set working directory
+WORKDIR /neosetup
+
+USER testuser

--- a/docker/Dockerfile.parrot-security
+++ b/docker/Dockerfile.parrot-security
@@ -1,0 +1,56 @@
+# Test container for parrot-security
+FROM parrotsec/core
+
+# Install base packages including python3-venv
+RUN if [ -f /etc/debian_version ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 python3-pip python3-venv sudo curl wget git openssh-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ -f /etc/redhat-release ]; then \
+  if command -v dnf; then \
+    dnf install -y --allowerasing python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*; \
+  else \
+    yum install -y epel-release && \
+    yum install -y python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*; \
+  fi; \
+fi
+
+# Create test user
+RUN useradd -m -s /bin/bash testuser && \
+    echo 'testuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy requirements files
+COPY neosetup/requirements-runtime.txt /tmp/requirements-runtime.txt
+COPY neosetup/requirements.yml /tmp/requirements.yml
+
+# Create virtual environment and install from requirements
+RUN python3 -m venv /opt/ansible-venv && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir -r /tmp/requirements-runtime.txt && \
+    rm -rf /root/.cache/pip
+
+# Install Ansible Galaxy collections and roles
+RUN /opt/ansible-venv/bin/ansible-galaxy install -r /tmp/requirements.yml && \
+    rm -f /tmp/requirements-runtime.txt /tmp/requirements.yml
+
+# Add venv to PATH for all users (bashrc location differs between distros)
+RUN if [ -f /etc/bash.bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bash.bashrc; \
+    elif [ -f /etc/bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bashrc; \
+    fi
+RUN echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/profile
+
+# Verify installation
+RUN /opt/ansible-venv/bin/ansible --version && \
+    /opt/ansible-venv/bin/python3 -c "import yaml; print('PyYAML available')"
+
+# Set working directory
+WORKDIR /neosetup
+
+USER testuser

--- a/docker/Dockerfile.rocky-9
+++ b/docker/Dockerfile.rocky-9
@@ -1,0 +1,56 @@
+# Test container for rocky-9
+FROM rockylinux:9
+
+# Install base packages including python3-venv
+RUN if [ -f /etc/debian_version ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 python3-pip python3-venv sudo curl wget git openssh-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ -f /etc/redhat-release ]; then \
+  if command -v dnf; then \
+    dnf install -y --allowerasing python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*; \
+  else \
+    yum install -y epel-release && \
+    yum install -y python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*; \
+  fi; \
+fi
+
+# Create test user
+RUN useradd -m -s /bin/bash testuser && \
+    echo 'testuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy requirements files
+COPY neosetup/requirements-runtime.txt /tmp/requirements-runtime.txt
+COPY neosetup/requirements.yml /tmp/requirements.yml
+
+# Create virtual environment and install from requirements
+RUN python3 -m venv /opt/ansible-venv && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir -r /tmp/requirements-runtime.txt && \
+    rm -rf /root/.cache/pip
+
+# Install Ansible Galaxy collections and roles
+RUN /opt/ansible-venv/bin/ansible-galaxy install -r /tmp/requirements.yml && \
+    rm -f /tmp/requirements-runtime.txt /tmp/requirements.yml
+
+# Add venv to PATH for all users (bashrc location differs between distros)
+RUN if [ -f /etc/bash.bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bash.bashrc; \
+    elif [ -f /etc/bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bashrc; \
+    fi
+RUN echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/profile
+
+# Verify installation
+RUN /opt/ansible-venv/bin/ansible --version && \
+    /opt/ansible-venv/bin/python3 -c "import yaml; print('PyYAML available')"
+
+# Set working directory
+WORKDIR /neosetup
+
+USER testuser

--- a/docker/Dockerfile.ubuntu-22.04
+++ b/docker/Dockerfile.ubuntu-22.04
@@ -1,0 +1,56 @@
+# Test container for ubuntu-22.04
+FROM ubuntu:22.04
+
+# Install base packages including python3-venv
+RUN if [ -f /etc/debian_version ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 python3-pip python3-venv sudo curl wget git openssh-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ -f /etc/redhat-release ]; then \
+  if command -v dnf; then \
+    dnf install -y --allowerasing python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*; \
+  else \
+    yum install -y epel-release && \
+    yum install -y python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*; \
+  fi; \
+fi
+
+# Create test user
+RUN useradd -m -s /bin/bash testuser && \
+    echo 'testuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy requirements files
+COPY neosetup/requirements-runtime.txt /tmp/requirements-runtime.txt
+COPY neosetup/requirements.yml /tmp/requirements.yml
+
+# Create virtual environment and install from requirements
+RUN python3 -m venv /opt/ansible-venv && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir -r /tmp/requirements-runtime.txt && \
+    rm -rf /root/.cache/pip
+
+# Install Ansible Galaxy collections and roles
+RUN /opt/ansible-venv/bin/ansible-galaxy install -r /tmp/requirements.yml && \
+    rm -f /tmp/requirements-runtime.txt /tmp/requirements.yml
+
+# Add venv to PATH for all users (bashrc location differs between distros)
+RUN if [ -f /etc/bash.bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bash.bashrc; \
+    elif [ -f /etc/bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bashrc; \
+    fi
+RUN echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/profile
+
+# Verify installation
+RUN /opt/ansible-venv/bin/ansible --version && \
+    /opt/ansible-venv/bin/python3 -c "import yaml; print('PyYAML available')"
+
+# Set working directory
+WORKDIR /neosetup
+
+USER testuser

--- a/docker/Dockerfile.ubuntu-24.04
+++ b/docker/Dockerfile.ubuntu-24.04
@@ -1,0 +1,56 @@
+# Test container for ubuntu-24.04
+FROM ubuntu:24.04
+
+# Install base packages including python3-venv
+RUN if [ -f /etc/debian_version ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends python3 python3-pip python3-venv sudo curl wget git openssh-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ -f /etc/redhat-release ]; then \
+  if command -v dnf; then \
+    dnf install -y --allowerasing python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*; \
+  else \
+    yum install -y epel-release && \
+    yum install -y python3 python3-pip sudo curl wget git tar gzip openssh-clients && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*; \
+  fi; \
+fi
+
+# Create test user
+RUN useradd -m -s /bin/bash testuser && \
+    echo 'testuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Copy requirements files
+COPY neosetup/requirements-runtime.txt /tmp/requirements-runtime.txt
+COPY neosetup/requirements.yml /tmp/requirements.yml
+
+# Create virtual environment and install from requirements
+RUN python3 -m venv /opt/ansible-venv && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/ansible-venv/bin/pip install --no-cache-dir -r /tmp/requirements-runtime.txt && \
+    rm -rf /root/.cache/pip
+
+# Install Ansible Galaxy collections and roles
+RUN /opt/ansible-venv/bin/ansible-galaxy install -r /tmp/requirements.yml && \
+    rm -f /tmp/requirements-runtime.txt /tmp/requirements.yml
+
+# Add venv to PATH for all users (bashrc location differs between distros)
+RUN if [ -f /etc/bash.bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bash.bashrc; \
+    elif [ -f /etc/bashrc ]; then \
+      echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/bashrc; \
+    fi
+RUN echo 'export PATH="/opt/ansible-venv/bin:$PATH"' >> /etc/profile
+
+# Verify installation
+RUN /opt/ansible-venv/bin/ansible --version && \
+    /opt/ansible-venv/bin/python3 -c "import yaml; print('PyYAML available')"
+
+# Set working directory
+WORKDIR /neosetup
+
+USER testuser


### PR DESCRIPTION
# 🚀 NeoSetup Pull Request

## 📋 Description

Track Dockerfiles in git for better visibility and debugging. Remove binary validation from CI since container tests use dry-run mode and don't actually install tools. Add platform-specific binary name mapping for tools like `fd` that have different names on different distros.

**Changes:**
- Add `docker/` directory with 9 tracked Dockerfiles for all test distros
- Remove binary validation step from CI (tools not installed in dry-run mode)
- Add platform-specific binary name mapping (`fd` → `fdfind` on Debian/Ubuntu)
- Update workflow to use tracked Dockerfiles instead of generating dynamically
- Remove obsolete `neosetup/Dockerfile.dev-test-*` files
- Update `develop` script to validate tracked Dockerfiles with `docker build --check`

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🎨 Style/formatting change
- [x] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or modification
- [x] 🚀 CI/CD pipeline change

## 🎯 Operator/Component Affected

- [ ] 🎯 Base Operator
- [ ] 🟢 Matrix Operator
- [ ] 🦃 JiveTurkey Operator
- [ ] 🐚 Shell Role
- [ ] 🖥️ Tmux Role
- [ ] 🔧 Tools Role
- [x] 🐳 Docker Role
- [ ] 📚 Documentation
- [x] 🧪 Testing Infrastructure
- [x] 🏗️ Build System

## ✅ Testing Checklist

- [x] 🐳 Pre-commit passes (`docker run --rm -v $(pwd):/workspace neosetup-precommit`)
- [x] 🧪 All existing tests pass
- [x] ✅ Operator validation passes (`python3 scripts/validate_operator.py --all`)
- [ ] 🔄 Dry-run test completed (`make dry-run OPERATOR=<operator>`)
- [x] 🐳 Multi-OS compatibility considered/tested
- [ ] 📚 Documentation updated

## 🟢 Matrix Theme Compliance

N/A - Infrastructure changes only

## 🔗 Related Issues

- Closes #62

## 🧪 How Has This Been Tested?

**Test Configuration:**

- OS: macOS (darwin)
- Operator tested: base
- Ansible version: N/A (infrastructure change)

**Test commands run:**

```bash
# Pre-commit in Docker
docker run --rm -v $(pwd):/workspace neosetup-precommit run --all-files

# Binary validation locally
python3 .github/scripts/test_binary_validation.py --os darwin --operator base -v

# Dockerfile syntax validation
docker build --check -f docker/Dockerfile.ubuntu-22.04 .
```

## 📸 Screenshots/Logs

N/A

## 📚 Additional Notes

- Binary validation script is still available for local testing
- Dockerfiles are now tracked in `docker/` directory for PR visibility
- Removed dynamic Dockerfile generation from CI workflow
- Updated `develop` script to use tracked Dockerfiles

---

> This PR contributes to making NeoSetup the best Ansible automation system ever!