### PR TITLE
fix: correct Docker service name for Kali Linux

### DIFF
--- a/neosetup/roles/docker/tasks/main.yml
+++ b/neosetup/roles/docker/tasks/main.yml
@@ -187,7 +187,7 @@
 
 - name: "🚀 Start and enable Docker service (Kali)"
   systemd:
-    name: docker.io
+    name: docker
     state: started
     enabled: yes
   become: yes


### PR DESCRIPTION
# 🚀 NeoSetup Pull Request

## 📋 Description

Fix Docker service name on Kali Linux. The systemd service is named `docker`, not `docker.io`. The package is `docker.io` but the service is `docker`.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🎨 Style/formatting change
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or modification
- [ ] 🚀 CI/CD pipeline change

## 🎯 Operator/Component Affected

- [x] 🎯 Base Operator
- [x] 🟢 Matrix Operator
- [x] 🦃 JiveTurkey Operator
- [ ] 🐚 Shell Role
- [ ] 🖥️ Tmux Role
- [ ] 🔧 Tools Role
- [x] 🐳 Docker Role
- [ ] 📚 Documentation
- [ ] 🧪 Testing Infrastructure
- [ ] 🏗️ Build System

## ✅ Testing Checklist

- [x] 🐳 Pre-commit passes (`./scripts/run-precommit.sh run --all-files`)
- [x] 🧪 All existing tests pass
- [x] ✅ Operator validation passes (`python3 scripts/validate_operator.py --all`)
- [ ] 🔄 Dry-run test completed (`make dry-run OPERATOR=<operator>`)
- [x] 🐳 Multi-OS compatibility considered/tested
- [ ] 📚 Documentation updated

## 🟢 Matrix Theme Compliance

- [ ] 🟢 Uses Matrix green color scheme (#00ff00)
- [ ] 🎭 Matrix ASCII art/effects work correctly
- [ ] 🎨 Terminal output maintains Matrix aesthetic
- [ ] 🔧 Matrix-specific functions/aliases included

N/A - Bug fix only

## 🔗 Related Issues

- Fixes Docker installation on Kali Linux

## 🧪 How Has This Been Tested?

**Test Configuration:**

- OS: Kali Linux (rolling)
- Operator tested: jiveturkey
- Ansible version: 2.17+

**Test commands run:**

```bash
# On Kali Linux
make install OPERATOR=jiveturkey

# Verify service name
systemctl status docker
```

## 📸 Screenshots/Logs

Error before fix:
```
TASK [docker : 🚀 Start and enable Docker service (Kali)]
fatal: [localhost]: FAILED! => 
    msg: 'Could not find the requested service docker.io: host'
```

## 📚 Additional Notes

- The package name is `docker.io` (Debian/Kali naming)
- The systemd service name is `docker`
- This is a common confusion on Debian-based systems

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)