### PR TITLE
fix: support Podman as Docker backend on Kali Linux

### DIFF
--- a/neosetup/roles/docker/handlers/main.yml
+++ b/neosetup/roles/docker/handlers/main.yml
@@ -1,17 +1,21 @@
 ---
 # Docker role handlers
 
-- name: Restart docker
+- name: restart docker
   systemd:
-    name: "{{ 'docker.io' if ansible_distribution == 'Kali' else 'docker' }}"
+    name: docker
     state: restarted
     daemon_reload: yes
   become: yes
-  when: ansible_os_family != "Darwin"
+  when:
+    - ansible_os_family != "Darwin"
+    - podman_docker_check.rc != 0
 
-- name: Reload docker
+- name: reload docker
   systemd:
-    name: "{{ 'docker.io' if ansible_distribution == 'Kali' else 'docker' }}"
+    name: docker
     state: reloaded
   become: yes
-  when: ansible_os_family != "Darwin"
+  when:
+    - ansible_os_family != "Darwin"
+    - podman_docker_check.rc != 0

--- a/neosetup/roles/docker/tasks/main.yml
+++ b/neosetup/roles/docker/tasks/main.yml
@@ -8,10 +8,17 @@
   failed_when: false
   changed_when: false
 
+- name: "🔍 Check if Podman is providing Docker compatibility"
+  shell: docker --version 2>&1 | grep -qi podman
+  register: podman_docker_check
+  failed_when: false
+  changed_when: false
+
 - name: "📋 Display Docker installation status"
   debug:
     msg: |
       🐳 Docker Status: {{ 'Already installed' if docker_check.rc == 0 else 'Not found - will install' }}
+      🦭 Podman Mode: {{ 'Yes (podman-docker)' if podman_docker_check.rc == 0 else 'No (native Docker)' }}
       💻 OS Family: {{ ansible_os_family }}
       📦 Distribution: {{ ansible_distribution | default('Unknown') }}
 
@@ -185,7 +192,18 @@
     - neosetup_add_user_to_docker | default(true)
     - ansible_os_family != "Darwin"
 
-- name: "🚀 Start and enable Docker service (Kali)"
+- name: "🦭 Enable Podman socket (when using podman-docker)"
+  systemd:
+    name: podman.socket
+    state: started
+    enabled: yes
+    scope: user
+  when:
+    - podman_docker_check.rc == 0
+    - ansible_os_family != "Darwin"
+  register: podman_socket_result
+
+- name: "🚀 Start and enable Docker service (Kali - native Docker only)"
   systemd:
     name: docker
     state: started
@@ -193,9 +211,10 @@
   become: yes
   when:
     - ansible_distribution == "Kali"
+    - podman_docker_check.rc != 0
   register: docker_service_result_kali
 
-- name: "🚀 Start and enable Docker service (Other Linux)"
+- name: "🚀 Start and enable Docker service (Other Linux - native Docker only)"
   systemd:
     name: docker
     state: started
@@ -204,6 +223,7 @@
   when:
     - ansible_os_family != "Darwin"
     - ansible_distribution != "Kali"
+    - podman_docker_check.rc != 0
   register: docker_service_result_other
 
 - name: "🔍 Verify Docker installation"
@@ -231,19 +251,22 @@
       🐳 Docker Installation Summary:
       ═══════════════════════════════
       📦 Version: {{ docker_version.stdout | default('Check manually') }}
-      🔧 Service Status: {{ 'Started' if ansible_os_family != 'Darwin' else 'Manual start required (macOS)' }}
+      🦭 Backend: {{ 'Podman (daemonless)' if podman_docker_check.rc == 0 else 'Docker Engine' }}
+      🔧 Service Status: {{ 'Podman socket enabled' if podman_docker_check.rc == 0 else ('Started' if ansible_os_family != 'Darwin' else 'Manual start required (macOS)') }}
       👥 User Groups: {{ 'Added to docker group' if ansible_os_family != 'Darwin' else 'Not applicable (macOS)' }}
-      🏗️ BuildKit: {{ 'Enabled' if docker_buildkit.enabled | default(true) else 'Disabled' }}
-      📦 Compose v2: {{ 'Installed' if docker_install_compose | default(true) else 'Not installed' }}
-      🔒 Security: {{ 'Enhanced' if docker_security is defined else 'Default' }}
+      🏗️ BuildKit: {{ 'N/A (Podman)' if podman_docker_check.rc == 0 else ('Enabled' if docker_buildkit.enabled | default(true) else 'Disabled') }}
+      📦 Compose: {{ 'podman-compose' if podman_docker_check.rc == 0 else ('Installed' if docker_install_compose | default(true) else 'Not installed') }}
+      🔒 Security: {{ 'Rootless by default' if podman_docker_check.rc == 0 else ('Enhanced' if docker_security is defined else 'Default') }}
       🧪 Test Result: {{ 'Skipped on macOS' if ansible_os_family == 'Darwin' else 'Check with: docker run hello-world' }}
 
       💡 Next steps:
       {% if ansible_os_family == "Darwin" %}
       - Start Docker Desktop application
+      {% elif podman_docker_check.rc == 0 %}
+      - Podman is daemonless - no service needed!
+      - Use 'docker' commands as normal (aliased to podman)
       {% else %}
       - Log out and back in for group changes to take effect
       {% endif %}
       - Test with: docker run hello-world
       - Use 'docker compose' (v2) instead of 'docker-compose'
-      - BuildKit is enabled for faster builds

--- a/neosetup/roles/docker/tasks/main.yml
+++ b/neosetup/roles/docker/tasks/main.yml
@@ -243,7 +243,9 @@
 
 - name: "🔧 Configure Docker with modern features"
   include_tasks: configure_docker.yml
-  when: docker_check.rc == 0 or docker_version.rc == 0
+  when:
+    - docker_check.rc == 0 or docker_version.rc == 0
+    - podman_docker_check.rc != 0
 
 - name: "✅ Docker installation complete"
   debug:


### PR DESCRIPTION
# 🚀 NeoSetup Pull Request

## 📋 Description

Fix Docker role to support Kali Linux with Podman. Kali ships with `podman-docker` by default, which provides Docker CLI compatibility using Podman as the backend. This PR:

- Detects when podman-docker is providing Docker compatibility
- Skips Docker daemon service start (Podman is daemonless)
- Skips Docker daemon configuration (no daemon.json needed)
- Enables Podman socket for API compatibility
- Updates summary to show Podman-specific info
- Fixes handler name case mismatch and service name

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🎨 Style/formatting change
- [ ] ♻️ Code refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or modification
- [ ] 🚀 CI/CD pipeline change

## 🎯 Operator/Component Affected

- [x] 🎯 Base Operator
- [x] 🟢 Matrix Operator
- [x] 🦃 JiveTurkey Operator
- [ ] 🐚 Shell Role
- [ ] 🖥️ Tmux Role
- [ ] 🔧 Tools Role
- [x] 🐳 Docker Role
- [ ] 📚 Documentation
- [ ] 🧪 Testing Infrastructure
- [ ] 🏗️ Build System

## ✅ Testing Checklist

- [x] 🐳 Pre-commit passes (`./scripts/run-precommit.sh run --all-files`)
- [x] 🧪 All existing tests pass
- [x] ✅ Operator validation passes (`python3 scripts/validate_operator.py --all`)
- [x] 🔄 Dry-run test completed (`make dry-run OPERATOR=<operator>`)
- [x] 🐳 Multi-OS compatibility considered/tested
- [ ] 📚 Documentation updated

## 🟢 Matrix Theme Compliance

N/A - Bug fix only

## 🔗 Related Issues

- Fixes Docker installation failure on Kali Linux with podman-docker

## 🧪 How Has This Been Tested?

**Test Configuration:**

- OS: Kali Linux (rolling) VM
- Operator tested: jiveturkey
- Ansible version: 2.17+

**Test commands run:**

```bash
cd neosetup
make install OPERATOR=jiveturkey
```

## 📸 Screenshots/Logs

Before fix:
```
TASK [docker : 🚀 Start and enable Docker service (Kali)]
fatal: [localhost]: FAILED! => 
    msg: 'Could not find the requested service docker.io: host'
```

After fix:
```
🐳 Docker Installation Summary:
═══════════════════════════════
📦 Version: podman version 5.4.2
🦭 Backend: Podman (daemonless)
🔧 Service Status: Podman socket enabled
👥 User Groups: Added to docker group
🏗️ BuildKit: N/A (Podman)
📦 Compose: podman-compose
🔒 Security: Rootless by default

ok=82   changed=9   failed=0
```

## 📚 Additional Notes

- Kali Linux ships with `podman-docker` by default
- Podman is daemonless - no systemd service needed
- The `docker` command is aliased to `podman`
- Container tests skip the docker role, so this wasn't caught in CI

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)