### PR TITLE
fix: define ls family as functions, not operator aliases

### DIFF
--- a/neosetup/operators/base/vars.yml
+++ b/neosetup/operators/base/vars.yml
@@ -27,10 +27,10 @@ shell_config:
     "..": "cd .."
     "...": "cd ../.."
     "~": "cd ~"
-    # File operations
-    "ll": "ls -alF"
-    "la": "ls -A"
-    "l": "ls -CF"
+    # File operations: ls / ll / la / l / lt / l. are defined as
+    # argument-forwarding functions in shared/aliases.j2 (eza-aware). Do not
+    # re-declare them as aliases here — aliases shadow the functions in zsh and
+    # can pass ls-only flags (e.g. -A, -CF) that eza does not understand.
     # Git shortcuts
     "gs": "git status"
     "ga": "git add"

--- a/neosetup/operators/jiveturkey/vars.yml
+++ b/neosetup/operators/jiveturkey/vars.yml
@@ -46,12 +46,11 @@ shell_config:
     "~": "cd ~"
     "back": "cd -"
 
-    # Better ls with eza fallback
-    "ll": "eza -la --color=always --group-directories-first 2>/dev/null || ls -alF --color=auto"
-    "la": "eza -a --color=always --group-directories-first 2>/dev/null || ls -A --color=auto"
-    "ls": "eza --color=always --group-directories-first 2>/dev/null || ls --color=auto"
-    "lt": "eza -T --color=always --group-directories-first 2>/dev/null || tree"
-    "l.": "eza -a | grep -E '^\\.' 2>/dev/null || ls -la | grep '^\\.' "
+    # ls / ll / la / lt / l. are defined as argument-forwarding functions in
+    # roles/shell/templates/shared/aliases.j2 (eza with a clean ls fallback).
+    # Do NOT re-declare them here as aliases: an alias of the form
+    # "eza ... || ls ..." cannot forward flags (e.g. `ls -al` lands on the
+    # dead `||` branch), and aliases shadow the functions in zsh.
 
     # Git power user
     "g": "git"

--- a/neosetup/roles/shell/templates/shared/aliases.j2
+++ b/neosetup/roles/shell/templates/shared/aliases.j2
@@ -106,6 +106,21 @@ tree() {
     command tree "$@"
   fi
 }
+lt() {
+  if command -v eza &>/dev/null; then
+    eza -T --color=always --group-directories-first --icons "$@"
+  else
+    command tree "$@"
+  fi
+}
+# Show hidden (dot) entries only, without recursing into them
+l.() {
+  if command -v eza &>/dev/null; then
+    eza -d --color=always --icons "$@" .* 2>/dev/null
+  else
+    command ls -d --color=auto "$@" .* 2>/dev/null
+  fi
+}
 command -v bat &>/dev/null && alias cat='bat'
 command -v rg &>/dev/null && alias grep='rg'
 command -v fd &>/dev/null && alias find='fd'


### PR DESCRIPTION
## What

`ls -al` silently dropped its flags and rendered the default grid instead of a long listing. Same defect hit `ll`, `la`, `lt`, `l.`.

## Root cause

Operators redeclared the ls family as `shell_aliases` shaped `eza … || ls …`. An alias does textual substitution, so `ls -al` expanded to `eza … || ls --color=auto -al` — the `-al` landed on the dead `||` branch, eza ran bare (exit 0), and the fallback never executed. Aliases also shadow the argument-forwarding functions added in PR #79, since aliases beat functions in zsh.

## Fix

- `roles/shell/templates/shared/aliases.j2`: add `lt()` and `l.()` as eza-aware, `"$@"`-forwarding functions so the whole ls family is functions.
- `operators/base/vars.yml`: drop `ll`/`la`/`l` aliases (`la="ls -A"`, `l="ls -CF"` feed eza flags it rejects once `ls` is a function).
- `operators/jiveturkey/vars.yml`: drop `ls`/`ll`/`la`/`lt`/`l.` alias overrides.

## Verification

Rendered the template and sourced it in zsh: **9/9 assertions pass** with explicit path — flags forwarded, no shadowing, `l.` dot-only, no eza "unknown argument" errors.
