### PR TITLE
fix(tools): make nodejs_dev and go_dev operators install their toolchains (#24, #25)

### DIFF
--- a/neosetup/operators/go_dev/vars.yml
+++ b/neosetup/operators/go_dev/vars.yml
@@ -46,43 +46,12 @@ go_config:
 
 # Tool configuration
 tools_config:
-  additional_tools:
-    # Language server and IDE support
-    - gopls
-    - goimports
-    - gofumpt
-    # Linting and code quality
-    - golangci-lint
-    - staticcheck
-    - gosec
-    # Testing tools
-    - gotestsum
-    - gotest
-    - mockgen
-    - gomock
-    # Code generation
-    - stringer
-    - go-enum
-    - wire
-    # Protocol Buffers and gRPC
-    - protoc
-    - protoc-gen-go
-    - protoc-gen-go-grpc
-    # Development utilities
-    - air  # Hot reload
-    - gore  # REPL
-    - delve  # Debugger
-    - cobra-cli  # CLI scaffolding
-    # Database tools
-    - migrate
-    - sqlc
-    - goose
-    # Build and release
-    - goreleaser
-    - ko
-    # Documentation
-    - godoc
-    - pkgsite
+  # Go tooling is installed by the go ecosystem installer, NOT the generic
+  # package loop: `go` (via operator_tool_sets.go_dev in the tool registry)
+  # brings the toolchain, and go_dev_config.go_install_tools lists the tools to
+  # `go install`. These are go-install targets, not apt/brew/pip packages, so
+  # listing them here would silently no-op.
+  additional_tools: []
   go_specific_tools: true
 
 # Shell configuration optimized for Go development
@@ -265,11 +234,12 @@ go_dev_config:
   enable_cgo: true
   enable_vendoring: false
 
-  # Tools to install via go install
+  # Tools to install via `go install` (run by go_installer). These are module
+  # paths, not package names; they can drift over time and may need updating.
   go_install_tools:
     - golang.org/x/tools/gopls@latest
     - golang.org/x/tools/cmd/goimports@latest
     - github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     - github.com/go-delve/delve/cmd/dlv@latest
-    - github.com/cosmtrek/air@latest
+    - github.com/air-verse/air@latest
     - github.com/spf13/cobra-cli@latest

--- a/neosetup/operators/nodejs_dev/vars.yml
+++ b/neosetup/operators/nodejs_dev/vars.yml
@@ -47,40 +47,12 @@ nodejs_config:
 
 # Tool configuration
 tools_config:
-  additional_tools:
-    # Version managers
-    - nvm
-    # Package managers
-    - yarn
-    - pnpm
-    # Development utilities
-    - typescript
-    - ts-node
-    - tsx
-    - nodemon
-    - pm2
-    # Code quality
-    - eslint
-    - prettier
-    # Build tools
-    - vite
-    - esbuild
-    # Testing
-    - jest
-    - vitest
-    # Full-stack frameworks CLI
-    - "@nestjs/cli"
-    - "create-next-app"
-    - "create-vite"
-    # Monorepo tools
-    - turbo
-    - nx
-    # Utilities
-    - npkill
-    - npm-check-updates
-    - depcheck
-    - serve
-    - http-server
+  # Node.js tooling is installed by the nvm ecosystem installer, NOT the generic
+  # package loop: `nvm` (via operator_tool_sets.nodejs_dev in the tool registry)
+  # brings Node.js/npm, and nodejs_dev_config.global_packages lists the global
+  # npm CLIs to install. npm/yarn/pnpm/tsc/eslint/... are not apt/brew/pip
+  # packages, so listing them here would silently no-op.
+  additional_tools: []
   nodejs_specific_tools: true
 
 # Shell configuration optimized for Node.js development
@@ -180,7 +152,7 @@ shell_functions:
         echo "NVM Version: $(nvm --version)"
         echo "NVM Current: $(nvm current)"
       fi
-      echo "Node Path: $(which node 2>/dev/null || echo 'Not found'kasync)"
+      echo "Node Path: $(which node 2>/dev/null || echo 'Not found')"
 
   - name: "node-clean"
     description: "Clean node_modules and lock files recursively"
@@ -242,10 +214,17 @@ nodejs_dev_config:
   prefer_pnpm: true
   use_corepack: false
 
-  # Global packages to install
+  # Global npm packages installed by nvm_installer after Node.js is set up.
+  # Covers the CLIs the operator's aliases/functions assume (yarn, pnpm, tsc,
+  # eslint, prettier, ...).
   global_packages:
+    - yarn
+    - pnpm
     - typescript
     - ts-node
+    - tsx
     - nodemon
+    - eslint
+    - prettier
     - npm-check-updates
     - serve

--- a/neosetup/roles/tools/tasks/custom_installs/go_installer.yml
+++ b/neosetup/roles/tools/tasks/custom_installs/go_installer.yml
@@ -1,0 +1,105 @@
+---
+# Custom installation for Go - toolchain + go-install-based developer tools
+#
+# The go_dev operator's aliases/functions (go build/test, gopls, golangci-lint,
+# air, dlv, ...) assume a real Go toolchain. Go tooling does not map to
+# apt/brew/pip cleanly, so this ecosystem installer owns it - mirroring how
+# pyenv/poetry own Python. It installs the Go toolchain (Homebrew on macOS, the
+# official tarball on Linux) and then `go install`s the tools the operator lists
+# in go_dev_config.go_install_tools.
+#
+# Version policy: a fully pinned go_config.go_version (X.Y.Z) is honored; a
+# partial value (e.g. "1.22") cannot form a valid download URL, so we resolve
+# the latest stable release from go.dev instead. macOS uses Homebrew's current
+# Go. Pinning to an exact series on all platforms is a follow-up.
+
+- name: "🐹 Install Go toolchain and developer tools"
+  block:
+    - name: "🔍 Check for an existing Go toolchain"
+      command: go version
+      register: go_check
+      ignore_errors: yes
+      changed_when: false
+
+    # --- macOS: Homebrew ---
+    - name: "🍎 Install Go via Homebrew (macOS)"
+      when:
+        - ansible_os_family == "Darwin"
+        - go_check.rc != 0
+      homebrew:
+        name: go
+        state: present
+
+    # --- Linux: official tarball ---
+    - name: "🔎 Resolve latest stable Go version"
+      when:
+        - platform_key in ['ubuntu', 'debian', 'redhat', 'wsl']
+        - go_check.rc != 0
+      uri:
+        url: https://go.dev/VERSION?m=text
+        return_content: yes
+      register: go_version_lookup
+
+    - name: "🧮 Select Go version and architecture (Linux)"
+      when:
+        - platform_key in ['ubuntu', 'debian', 'redhat', 'wsl']
+        - go_check.rc != 0
+      set_fact:
+        go_target: >-
+          {{ ('go' + go_config.go_version)
+             if (go_config.go_version | default('') | regex_search('^[0-9]+\.[0-9]+\.[0-9]+$'))
+             else (go_version_lookup.content | trim | split('\n') | first) }}
+        go_arch: "{{ 'arm64' if ansible_architecture in ['aarch64', 'arm64'] else 'amd64' }}"
+
+    - name: "🧹 Remove any previous Go install (Linux)"
+      when:
+        - platform_key in ['ubuntu', 'debian', 'redhat', 'wsl']
+        - go_check.rc != 0
+      become: yes
+      file:
+        path: /usr/local/go
+        state: absent
+
+    - name: "🔽 Download and extract Go to /usr/local (Linux)"
+      when:
+        - platform_key in ['ubuntu', 'debian', 'redhat', 'wsl']
+        - go_check.rc != 0
+      become: yes
+      unarchive:
+        src: "https://go.dev/dl/{{ go_target }}.linux-{{ go_arch }}.tar.gz"
+        dest: /usr/local
+        remote_src: yes
+        creates: /usr/local/go/bin/go
+
+    - name: "📝 Ensure Go is on PATH from shell rc"
+      blockinfile:
+        path: "{{ ansible_env.HOME }}/.{{ ansible_env.SHELL | basename }}rc"
+        create: yes
+        marker: "# {mark} NEOSETUP GO"
+        block: |
+          export PATH="$PATH:/usr/local/go/bin:$HOME/go/bin"
+
+    - name: "🔧 Install Go developer tools via go install"
+      when: go_config.install_tools | default(true)
+      shell: |
+        export PATH="$PATH:/usr/local/go/bin:/opt/homebrew/bin:/usr/local/bin:{{ ansible_env.HOME }}/go/bin"
+        export GOPATH="{{ ansible_env.HOME }}/go"
+        export GOBIN="{{ ansible_env.HOME }}/go/bin"
+        go install {{ item }}
+      args:
+        executable: /bin/bash
+        creates: "{{ ansible_env.HOME }}/go/bin/{{ item | regex_replace('^.*/([^/@]+)@.*$', '\\1') }}"
+      loop: "{{ go_dev_config.go_install_tools | default([]) }}"
+
+- name: "✅ Go toolchain installation complete"
+  debug:
+    msg: |
+      🐹 Go toolchain installed
+      📂 GOROOT: {{ '/usr/local/go' if platform_key != 'darwin' else '(Homebrew)' }}
+      📂 GOPATH: {{ ansible_env.HOME }}/go
+      🔧 Tools:  {{ go_dev_config.go_install_tools | default([]) | length }} installed via `go install`
+
+      💡 Usage (open a new shell first):
+      - Verify:  go version
+      - Lint:    golangci-lint run
+      - Hot reload: air

--- a/neosetup/roles/tools/tasks/custom_installs/nvm_installer.yml
+++ b/neosetup/roles/tools/tasks/custom_installs/nvm_installer.yml
@@ -1,0 +1,80 @@
+---
+# Custom installation for nvm - Node.js version manager + global npm tooling
+#
+# The nodejs_dev operator's aliases/functions (node, npm, yarn, pnpm, tsc, ...)
+# assume a real Node.js toolchain. Node tooling does not map to apt/brew/pip, so
+# this ecosystem installer owns it end to end - mirroring how pyenv/poetry own
+# the Python toolchain. It installs nvm, the configured Node.js version(s), sets
+# a default, then installs the global npm CLIs the operator advertises.
+
+- name: "⬢ Install Node.js toolchain via nvm"
+  block:
+    - name: "🔍 Check if nvm is already installed"
+      stat:
+        path: "{{ ansible_env.HOME }}/.nvm/nvm.sh"
+      register: nvm_check
+
+    - name: "🔽 Install nvm via official install script"
+      when: not nvm_check.stat.exists
+      shell: |
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+      args:
+        creates: "{{ ansible_env.HOME }}/.nvm/nvm.sh"
+
+    - name: "📝 Ensure nvm is sourced from shell rc"
+      blockinfile:
+        path: "{{ ansible_env.HOME }}/.{{ ansible_env.SHELL | basename }}rc"
+        create: yes
+        marker: "# {mark} NEOSETUP NVM"
+        block: |
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+
+    - name: "🔧 Install configured Node.js version(s)"
+      shell: |
+        export NVM_DIR="$HOME/.nvm"
+        . "$NVM_DIR/nvm.sh"
+        nvm install {{ item }}
+      args:
+        executable: /bin/bash
+      loop: "{{ nodejs_config.default_node_versions | default(['20']) }}"
+      register: nvm_install
+      changed_when: "'is already installed' not in (nvm_install.stdout + nvm_install.stderr)"
+
+    - name: "🎯 Set default Node.js version"
+      when: nodejs_config.global_node_version is defined
+      shell: |
+        export NVM_DIR="$HOME/.nvm"
+        . "$NVM_DIR/nvm.sh"
+        nvm alias default {{ nodejs_config.global_node_version }}
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+    - name: "📦 Install global npm packages"
+      when:
+        - nodejs_config.install_global_packages | default(true)
+        - nodejs_dev_config.global_packages | default([]) | length > 0
+      shell: |
+        export NVM_DIR="$HOME/.nvm"
+        . "$NVM_DIR/nvm.sh"
+        nvm use default >/dev/null 2>&1 || true
+        npm install -g {{ nodejs_dev_config.global_packages | join(' ') }}
+      args:
+        executable: /bin/bash
+      register: npm_globals
+      changed_when: "'added' in (npm_globals.stdout | default('')) or 'changed' in (npm_globals.stdout | default(''))"
+
+- name: "✅ Node.js toolchain installation complete"
+  debug:
+    msg: |
+      ⬢ Node.js toolchain installed via nvm
+      📂 NVM_DIR: {{ ansible_env.HOME }}/.nvm
+      🔧 Versions: {{ nodejs_config.default_node_versions | default(['20']) | join(', ') }}
+      🎯 Default: {{ nodejs_config.global_node_version | default('20') }}
+
+      💡 Usage (open a new shell first):
+      - Switch version:  nvm use 22
+      - List versions:   nvm ls
+      - Install latest:  nvm install --lts

--- a/neosetup/roles/tools/vars/tool_registry.yml
+++ b/neosetup/roles/tools/vars/tool_registry.yml
@@ -441,6 +441,26 @@ tool_registry:
     packages:
       pipx: cookiecutter
 
+  # Node.js development tools
+  # The ecosystem installer owns node itself plus the global npm CLIs
+  # (yarn, pnpm, typescript, eslint, ...) since none map to apt/brew/pip.
+  nvm:
+    description: "Node.js version manager and global npm tooling"
+    category: nodejs
+    custom_install: nvm_installer
+    packages:
+      # Node.js tooling requires custom installation on all platforms
+
+  # Go development tools
+  # The ecosystem installer owns the toolchain plus go-install tools
+  # (gopls, golangci-lint, dlv, air, ...) since none map to apt/brew/pip.
+  go:
+    description: "Go toolchain and go-install-based developer tools"
+    category: go
+    custom_install: go_installer
+    packages:
+      # Go tooling requires custom installation on all platforms
+
   # Cloud and DevOps tools
   awscli:
     description: "Amazon Web Services CLI"
@@ -557,6 +577,12 @@ operator_tool_sets:
     - ipython
     - jupyter
     - cookiecutter
+
+  nodejs_dev:
+    - nvm
+
+  go_dev:
+    - go
 
   cloud_tools:
     - awscli


### PR DESCRIPTION
## The bug

The `nodejs_dev` and `go_dev` operators looked complete — full shell aliases, functions, and env — but installed **zero tooling**. Their tools were listed only in `tools_config.additional_tools`, and the install loop skips any item that isn't in the tool registry:

```yaml
when:
  - item in tool_registry   # <- none of the node/go tools were registered
```

So `make install OPERATOR=nodejs_dev` (or `go_dev`) applied dotfiles but never installed node, npm, go, or any of the advertised tools. This was surfaced by an open-issue triage against the codebase.

## The fix

Node and Go tooling doesn't map to apt/brew/pip, so this adds one **ecosystem installer** per language, mirroring the existing `pyenv`/`poetry` custom-install pattern:

- **`nvm_installer`** — installs nvm, the configured Node.js version(s) (`nodejs_config.default_node_versions`), sets a default, and installs the global npm CLIs (`nodejs_dev_config.global_packages`: yarn, pnpm, typescript, eslint, prettier, ...).
- **`go_installer`** — installs the Go toolchain (Homebrew on macOS, official tarball on Linux) and `go install`s the tools in `go_dev_config.go_install_tools`.

Wiring:
- New registry entries `nvm` and `go` (custom_install).
- New `operator_tool_sets.nodejs_dev` / `go_dev` keys — the same mechanism that makes `python_dev` work.
- Emptied the operators' `additional_tools` (they silently no-op'd) and pointed them at the installer-consumed config lists.

Also fixed:
- **`nodeinfo` typo** — a broken command substitution (`'Not found'kasync)`) that would error every time the function ran.
- **`air` module path** — `cosmtrek/air` → `air-verse/air` (the module was renamed; the old path fails `go install`).

## Design notes

- Go version: a fully-pinned `go_version` (X.Y.Z) is honored; a partial value (e.g. `1.22`) can't form a valid download URL, so the installer resolves the latest stable from go.dev. Pinning an exact series on all platforms is a follow-up.
- `go install` targets are module paths that drift over time and may need occasional updates.

## Testing

Validated:
- ✅ `ansible-lint --profile=basic` (Docker pre-commit) — passes, incl. both new installers
- ✅ `yamllint` — passes
- ✅ operator schema validation (`validate_operator.py --all`) — all 8 operators pass
- ✅ `ansible-playbook --syntax-check` for both operators

**Not** validated end-to-end: a full `make install` of the toolchains. The tools role is `--skip-tags`'d in container CI (see #77), and installing node/go system-wide isn't something this pass exercised. The installers follow the established custom-install idiom and are idempotent (`creates:`/check-guards), but first real-hardware runs should be watched.

Closes #24
Closes #25