### PR TITLE
feat(tools): monitoring, git-stats, and log tools (#34, #35, #36, #37)

### DIFF
--- a/neosetup/operators/jiveturkey/vars.yml
+++ b/neosetup/operators/jiveturkey/vars.yml
@@ -76,6 +76,7 @@ shell_config:
     "gstp": "git stash pop"
     "gundo": "git reset HEAD~1"
     "gwip": "git add -A && git commit -m 'WIP'"
+    "gstats": "git-quick-stats"
 
     # Docker mastery
     "d": "docker"
@@ -106,6 +107,12 @@ shell_config:
     "free": "free -h"
     "ports": "lsof -i -P -n | grep LISTEN"
     "psg": "ps aux | grep"
+    "disk": "duf 2>/dev/null || df -h"
+    "dash": "glances"
+
+    # Log viewing
+    "logview": "lnav"
+    "logtail": "multitail"
 
     # Network tools
     "myip": "curl -s https://ipinfo.io/ip"
@@ -195,6 +202,19 @@ shell_functions:
       echo "Shell: $SHELL"
       if command -v uptime &> /dev/null; then
           echo "Uptime: $(uptime | awk '{print $3,$4}' | sed 's/,//')"
+      fi
+
+  - name: "monitor"
+    description: "Launch the best available system-monitor dashboard"
+    body: |
+      if command -v glances &> /dev/null; then
+          glances
+      elif command -v btop &> /dev/null; then
+          btop
+      elif command -v htop &> /dev/null; then
+          htop
+      else
+          top
       fi
 
   # Security Docker functions

--- a/neosetup/roles/tools/vars/tool_registry.yml
+++ b/neosetup/roles/tools/vars/tool_registry.yml
@@ -461,6 +461,71 @@ tool_registry:
     packages:
       # Go tooling requires custom installation on all platforms
 
+  # Monitoring and observability tools
+  glances:
+    description: "Cross-platform system monitoring dashboard"
+    category: monitoring
+    packages:
+      darwin: glances
+      ubuntu: glances
+      debian: glances
+      redhat: glances
+
+  duf:
+    description: "Modern, colorful disk usage / free-space viewer"
+    category: monitoring
+    packages:
+      # Not in RHEL/EPEL base repos; installs on macOS and Debian/Ubuntu
+      darwin: duf
+      ubuntu: duf
+      debian: duf
+
+  procs:
+    description: "Modern ps replacement with a richer, colorized view"
+    category: monitoring
+    packages:
+      # Debian 12+ / Ubuntu 23.04+ ship this; older distros skip (ignore_errors)
+      darwin: procs
+      ubuntu: procs
+      debian: procs
+
+  # Git statistics and visualization tools
+  git-quick-stats:
+    description: "Git repository statistics and contribution reports"
+    category: git
+    packages:
+      darwin: git-quick-stats
+      ubuntu: git-quick-stats
+      debian: git-quick-stats
+
+  # Log aggregation and viewing tools
+  lnav:
+    description: "The Log File Navigator - interactive log viewer"
+    category: logs
+    packages:
+      darwin: lnav
+      ubuntu: lnav
+      debian: lnav
+      redhat: lnav
+
+  grc:
+    description: "Generic colouriser for command and log output"
+    category: logs
+    packages:
+      darwin: grc
+      ubuntu: grc
+      debian: grc
+      redhat: grc
+
+  multitail:
+    description: "Tail multiple log files in one split window"
+    category: logs
+    packages:
+      darwin: multitail
+      ubuntu: multitail
+      debian: multitail
+      redhat: multitail
+
   # Cloud and DevOps tools
   awscli:
     description: "Amazon Web Services CLI"
@@ -542,6 +607,16 @@ operator_tool_sets:
     - shellcheck
     - lazygit
     - gh
+    # Monitoring / observability
+    - glances
+    - duf
+    - procs
+    # Git statistics
+    - git-quick-stats
+    # Log viewing
+    - lnav
+    - grc
+    - multitail
 
   modern_cli:
     - eza


### PR DESCRIPTION
Adds observability/tooling from the Phase-6 issues, wired so they **actually install** — registered in `tool_registry.yml` and added to the `jiveturkey` power-user tool set. (Listing a tool without registering it silently no-ops; that's the gate that broke the Node/Go operators in #93.)

## Tools added

| Category | Tools | Issue |
|----------|-------|-------|
| Monitoring | `glances`, `duf`, `procs` | #34, #36 |
| Git stats | `git-quick-stats` | #35 |
| Logs | `lnav`, `grc`, `multitail` | #37 |

Plus `jiveturkey` aliases (`disk`, `dash`, `logview`, `logtail`, `gstats`) and a `monitor` function that launches the best available dashboard (`glances → btop → htop → top`).

## Honest scoping

Package names are per-platform and verified where the tool genuinely ships. **Brew-only tools were deferred, not faked** — `onefetch`/`git-sizer` (#35), `bottom` (#34), `bandwhich` (#36) aren't in standard apt/dnf repos, and shipping them with apt names would silently fail on Linux (the exact anti-pattern #93 fixed). `duf`/`procs` are darwin + Debian/Ubuntu only (not in RHEL base); older distros skip via the install loop's `ignore_errors`.

- **#37 fully addressed** → closes on merge.
- **#34 / #35 / #36 partially addressed** (core tools in; brew-only extras + custom htop layout deferred) → left open with this note so you can extend or close.

## Testing

- ✅ `ansible-lint` + `yamllint` (Docker pre-commit)
- ✅ operator schema validation (all 8 operators)
- ✅ `ansible-playbook --syntax-check` (jiveturkey)

Not exercised: a live `make install` (tools role is `--skip-tags`'d in container CI, see #77).

Closes #37
Refs #34, #35, #36